### PR TITLE
Add DST offset config

### DIFF
--- a/salah/app/src/main/AndroidManifest.xml
+++ b/salah/app/src/main/AndroidManifest.xml
@@ -66,6 +66,11 @@
             android:label="@string/prefs"
             android:exported="true">
         </activity>
+        <activity
+            android:name=".ConfigDSTActivity"
+            android:label="@string/prefs"
+            android:exported="true">
+        </activity>
         <!--service
             android:name=".tile.SalahTileProviderService"
             android:label="@string/title_activity_salah"

--- a/salah/app/src/main/java/com/tazzix/wear/salah/ConfigActivity.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/ConfigActivity.kt
@@ -34,8 +34,10 @@ class ConfigActivity : FragmentActivity() {
         val sharedPreferences =  getSharedPreferences("SALAH_LOCATION", Context.MODE_PRIVATE)
         val curMethod = resources.getStringArray(R.array.array_methods)[sharedPreferences.getInt("METHOD", 0)]
         val curAsrCalc = resources.getStringArray(R.array.array_asrcalcs)[sharedPreferences.getInt("ASR_CALC", 0)]
+        val curDSTOffset = resources.getStringArray(R.array.array_dst_offsets)[sharedPreferences.getInt("DST_OFFSET", 1)]
         menuItems.add(MenuItem(android.R.drawable.ic_menu_compass, getString(R.string.method), curMethod))
         menuItems.add(MenuItem(android.R.drawable.ic_menu_info_details, getString(R.string.asr_calc), curAsrCalc))
+        menuItems.add(MenuItem(android.R.drawable.ic_menu_info_details, getString(R.string.dst_offset), curDSTOffset))
 
         recyclerView.adapter = MenuAdapter(context, R.layout.recview_item, menuItems, object: MenuAdapter.AdapterCallback {
             override fun onItemClicked(menuPosition: Int?) {
@@ -47,6 +49,10 @@ class ConfigActivity : FragmentActivity() {
                     }
                     1 -> {
                         val intent = Intent(context, ConfigAsrCalcActivity::class.java)
+                        startActivity(intent)
+                    }
+                    2 -> {
+                        val intent = Intent(context, ConfigDSTActivity::class.java)
                         startActivity(intent)
                     }
                     else -> {

--- a/salah/app/src/main/java/com/tazzix/wear/salah/ConfigDSTActivity.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/ConfigDSTActivity.kt
@@ -1,0 +1,39 @@
+package com.tazzix.wear.salah
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import androidx.fragment.app.FragmentActivity
+
+import androidx.wear.widget.WearableLinearLayoutManager
+import androidx.wear.widget.WearableRecyclerView
+
+
+class ConfigDSTActivity : FragmentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_config)
+
+        val recyclerView: WearableRecyclerView = findViewById(R.id.config_menu_view)
+        recyclerView.setHasFixedSize(true)
+        recyclerView.isEdgeItemsCenteringEnabled = true
+        recyclerView.layoutManager = WearableLinearLayoutManager(this)
+
+        val menuItems: ArrayList<MenuItem> = ArrayList()
+        val methods = resources.getStringArray(R.array.array_dst_offsets)
+
+        for (method in methods) {
+            menuItems.add(MenuItem(android.R.drawable.ic_menu_info_details, "", method))
+        }
+
+        recyclerView.adapter = MenuAdapter(this, R.layout.notitle_item, menuItems, object: MenuAdapter.AdapterCallback {
+            override fun onItemClicked(menuPosition: Int?) {
+                val sharedPreferences =  getSharedPreferences("SALAH_LOCATION", Context.MODE_PRIVATE)
+                sharedPreferences.edit().putInt("DST_OFFSET", menuPosition!!).apply()
+                finish()
+            }
+        })
+    }
+}

--- a/salah/app/src/main/java/com/tazzix/wear/salah/SalahActivity.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/SalahActivity.kt
@@ -77,7 +77,8 @@ class SalahActivity : FragmentActivity() {
                 val shPrefs = getSharedPreferences("SALAH_LOCATION",Context.MODE_PRIVATE)
                 val method = shPrefs.getInt("METHOD", 0)
                 val asrCalc = shPrefs.getInt("ASR_CALC", 0)
-                val location2 = MyLocation(location.location.latitude, location.location.longitude, method, asrCalc)
+                val dstOffset = shPrefs.getInt("DST_OFFSET", 1)
+                val location2 = MyLocation(location.location.latitude, location.location.longitude, method, asrCalc, dstOffset)
                 renderUI(location2, location.location.time, true, "")
                 // DONE: save location in SharedPrefs
                 val editor = shPrefs.edit()
@@ -105,12 +106,13 @@ class SalahActivity : FragmentActivity() {
         val lon = sharedPreference.getString("LL", "0.00")?.toDouble()!!
         val method = sharedPreference.getInt("METHOD", 0)
         val asrCalc = sharedPreference.getInt("ASR_CALC", 0)
+        val dstOffset = sharedPreference.getInt("DST_OFFSET", 1)
         val tm = sharedPreference.getLong("TM", 0)
         val locVal = sharedPreference.getString("LC", "N/A")!!
 
         // DONE: if location not found, put tap target
         if (lat!=0.0 && lon!=0.0) {
-            val location2 = MyLocation(lat, lon, method, asrCalc)
+            val location2 = MyLocation(lat, lon, method, asrCalc, dstOffset)
             renderUI(location2,tm, false, locVal)
         }
     }

--- a/salah/app/src/main/java/com/tazzix/wear/salah/complication/SalahComplicationProviderService.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/complication/SalahComplicationProviderService.kt
@@ -109,10 +109,11 @@ class SalahComplicationProviderService : CoroutinesComplicationDataSourceService
         val lon = sharedPreference.getString("LL", "0.00")?.toDouble()!!
         val method = sharedPreference.getInt("METHOD", 0)
         val asrCalc = sharedPreference.getInt("ASR_CALC", 0)
+        val dstOffset = sharedPreference.getInt("DST_OFFSET", 1)
 
         // DONE: if location not found, put tap target
         return if (lat!=0.0 && lon!=0.0) {
-            val location = MyLocation(lat, lon, method, asrCalc)
+            val location = MyLocation(lat, lon, method, asrCalc, dstOffset)
             val pInfo = getAddressDescription(location, false)
             val now = LocalTime.now().minusMinutes(15)
             var pts = arrayOf(

--- a/salah/app/src/main/java/com/tazzix/wear/salah/data/ResolvedLocation.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/data/ResolvedLocation.kt
@@ -24,7 +24,7 @@ object PermissionError: LocationResult()
 
 object NoLocation: LocationResult()
 
-data class MyLocation(val latitude: Double, val longitude: Double, val method: Int, val asrCalc: Int)
+data class MyLocation(val latitude: Double, val longitude: Double, val method: Int, val asrCalc: Int, val dstOffset: Int)
 
 data class PrayerInfo(val locality: String, val fajr: Time, val sunrise: Time, val dhuhur: Time, val asr: Time, val maghrib: Time, val isha: Time)
 

--- a/salah/app/src/main/java/com/tazzix/wear/salah/format.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/format.kt
@@ -30,7 +30,7 @@ fun getTimeAgo(time: Long): CharSequence {
 
 fun applyDSTOffset(ptimes: AzanTimes, dstOffset: Int) {
     for ((i, time) in ptimes.times.withIndex()) {
-        ptimes.times[i] = Time(time.hour+dstOffset, time.minute, time.second, time.isExtreme)
+        ptimes.times[i] = Time(time.hour+dstOffset-1, time.minute, time.second, time.isExtreme)
     }
 }
 

--- a/salah/app/src/main/java/com/tazzix/wear/salah/format.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/format.kt
@@ -28,6 +28,12 @@ fun getTimeAgo(time: Long): CharSequence {
     return DateUtils.getRelativeTimeSpanString(time)
 }
 
+fun applyDSTOffset(ptimes: AzanTimes, dstOffset: Int) {
+    for ((i, time) in ptimes.times.withIndex()) {
+        ptimes.times[i] = Time(time.hour+dstOffset, time.minute, time.second, time.isExtreme)
+    }
+}
+
 fun Context.getAddressDescription(location: MyLocation, resolveLocality: Boolean): PrayerInfo {
     var locationVal = "N/A"
     if (resolveLocality) {
@@ -47,7 +53,7 @@ fun Context.getAddressDescription(location: MyLocation, resolveLocality: Boolean
 
     val today = SimpleDate(GregorianCalendar())
     // Subtract 1 from DST due to bug in library: https://github.com/ahmedeltaher/Prayer-Times-Android-Azan/issues/27#issue-866377567
-    val loc = Location(location.latitude, location.longitude, TimeZone.getDefault().rawOffset.toDouble()/3600000, TimeZone.getDefault().dstSavings/3600000 - 1)
+    val loc = Location(location.latitude, location.longitude, TimeZone.getDefault().rawOffset.toDouble()/3600000, TimeZone.getDefault().dstSavings/3600000)
     val method = when(location.method) {
         0 -> Method.KARACHI_HANAF
         1 -> Method.UMM_ALQURRA
@@ -71,6 +77,7 @@ fun Context.getAddressDescription(location: MyLocation, resolveLocality: Boolean
     method.madhhab = if(location.asrCalc==0) Madhhab.HANAFI else Madhhab.SHAAFI
     val azan = Azan(loc, method)
     val ptimes = azan.getPrayerTimes(today)
+    applyDSTOffset(ptimes, location.dstOffset)
 
     return PrayerInfo(locationVal, ptimes.fajr(), ptimes.shuruq(), ptimes.thuhr(), ptimes.assr(), ptimes.maghrib(), ptimes.ishaa())
 }

--- a/salah/app/src/main/java/com/tazzix/wear/salah/format.kt
+++ b/salah/app/src/main/java/com/tazzix/wear/salah/format.kt
@@ -46,7 +46,8 @@ fun Context.getAddressDescription(location: MyLocation, resolveLocality: Boolean
     if (locationVal.isEmpty()) locationVal = String.format("%.3f, %.3f", location.latitude, location.longitude)
 
     val today = SimpleDate(GregorianCalendar())
-    val loc = Location(location.latitude, location.longitude, TimeZone.getDefault().rawOffset.toDouble()/3600000, TimeZone.getDefault().dstSavings/3600000)
+    // Subtract 1 from DST due to bug in library: https://github.com/ahmedeltaher/Prayer-Times-Android-Azan/issues/27#issue-866377567
+    val loc = Location(location.latitude, location.longitude, TimeZone.getDefault().rawOffset.toDouble()/3600000, TimeZone.getDefault().dstSavings/3600000 - 1)
     val method = when(location.method) {
         0 -> Method.KARACHI_HANAF
         1 -> Method.UMM_ALQURRA

--- a/salah/app/src/main/res/values/strings.xml
+++ b/salah/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="prefs">Preferences</string>
     <string name="method">Method</string>
     <string name="asr_calc">Asr Calc</string>
+    <string name="dst_offset">DST Offset</string>
 
     <string-array name="array_methods">
         <item>Karachi: University of Islamic Sciences</item>
@@ -44,5 +45,10 @@
     <string-array name="array_asrcalcs">
         <item>Hanafi</item>
         <item>Shaafi</item>
+    </string-array>
+    <string-array name="array_dst_offsets">
+        <item>-1 hour</item>
+        <item>0 hours</item>
+        <item>+1 hour</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Added a DST offset config which allows offsetting prayer times by -1, 0, or +1 hours. This allows adjusting in case there are errors in the prayer calculation library (see #4).

Originally, I hardcoded the adjustment, but realized the offset may not always be required/vary by location.

General Config Page:
![image](https://user-images.githubusercontent.com/5333243/205469487-784476c4-6b5f-4769-b9aa-e732851a7129.png)

DST Config Page:
![image](https://user-images.githubusercontent.com/5333243/205469483-361663f1-b61a-450d-aadd-a45f8f89af87.png)